### PR TITLE
Use DateTime object instead of timestamp for notifications

### DIFF
--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -181,9 +181,12 @@ class PageController extends Controller {
 			->setMessage('announcementmessage#' . $id, [$authorId])
 			->setObject('announcement', $id);
 
+		$dateTime = new \DateTime();
+		$dateTime->setTimestamp($timeStamp);
+
 		$notification = $this->notificationManager->createNotification();
 		$notification->setApp('announcementcenter')
-			->setTimestamp($timeStamp)
+			->setDateTime($dateTime)
 			->setObject('announcement', $id)
 			->setSubject('announced', [$authorId])
 			->setLink($this->urlGenerator->linkToRoute('announcementcenter.page.index'));

--- a/tests/controller/PageControllerTest.php
+++ b/tests/controller/PageControllerTest.php
@@ -354,9 +354,11 @@ class PageController extends TestCase {
 			->method('setApp')
 			->with('announcementcenter')
 			->willReturnSelf();
+		$dateTime = new \DateTime();
+		$dateTime->setTimestamp(1337);
 		$notification->expects($this->once())
-			->method('setTimestamp')
-			->with(1337)
+			->method('setDateTime')
+			->with($dateTime)
 			->willReturnSelf();
 		$notification->expects($this->once())
 			->method('setSubject')


### PR DESCRIPTION
- [x] Depends on owncloud/core#20577