### PR TITLE
chore: bump version to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased] - XXXX-XX-XX
 
 
+## [1.3.1] - 2026-07-22
+
+### Changed
+- Maintenance release re-signed with the ownCloud G2 code-signing certificate for the ownCloud 11.0.0 release.
+
+## [1.3.0] - 2026-06-29
+
+### Changed
+- ownCloud 11 compatible release (oc 11.0.0-rc1).
 
 ## [1.2.2] - 2021-06-18
 
@@ -33,7 +42,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Allow announcements without messages - [#86](https://github.com/owncloud/announcementcenter/pull/86)
 
-[Unreleased]: https://github.com/owncloud/announcementcenter/compare/v1.2.2...master
+[Unreleased]: https://github.com/owncloud/announcementcenter/compare/v1.3.1..master
+[1.3.1]: https://github.com/owncloud/announcementcenter/compare/v1.3.0..v1.3.1
+[1.3.0]: https://github.com/owncloud/announcementcenter/compare/v1.2.2..v1.3.0
 [1.2.2]: https://github.com/owncloud/announcementcenter/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/owncloud/announcementcenter/compare/v1.2.0...v1.2.1
-

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<description>This application enables admins to notify users about e.g. upcoming maintenance windows or changed features. Notifications are sent via Activity mails, the notification bell in the WebUI and ownCloud clients display them as well.</description>
 	<licence>AGPL</licence>
 	<author>Joas Schilling</author>
-	<version>1.3.0</version>
+	<version>1.3.1</version>
 	<namespace>AnnouncementCenter</namespace>
 
 	<category>tools</category>


### PR DESCRIPTION
Patch-level version bump (1.3.0 -> 1.3.1) for the oc11 (11.0.0) complete release. Part of the G2 code-signing re-release.